### PR TITLE
Fix circleci docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:8.12
+      - image: circleci/node:8.12-browsers
 
     working_directory: ~/repo
 


### PR DESCRIPTION
This PR change the CircleCI docker image to an image that supports electron.